### PR TITLE
Some trivial fixes to src/server.c::runServer()

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -68,7 +68,7 @@ void runServer(App *app) {
 
     struct sockaddr_in address = {0};
     address.sin_family = AF_INET;
-    address.sin_addr.s_addr = htonl(INADDR_ANY);
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     address.sin_port = htons(app->server.port);
 
     if (bind(app->server.fileDescriptor, (struct sockaddr *)&address, sizeof(address)) < 0) {


### PR DESCRIPTION
Good to see I'm not the only one still writing new projects in C despite the doom-mongers!

* Zero initialise the address structure in runServer()

This simply initialises the address structure before the setting of some of the members before passing it into bind(2).

* Use htonl(3) on the INADDR_ANY macro

The sin_addr.s_addr member should be specified in network byte-order.

* Really only listen on the loopback interface

Use INADDR_LOOPBACK instead of INADDR_ANY. This better matches the documentation.

I can drop this patch if listening on 0.0.0.0 is really the intention at this stage. However seeing as this is early days, there is perhaps some advantage to not exposing it to the wider network just yet.