### PR TITLE
fix: replace strcmp() with constant-time secureEquals() to prevent timing oracle in basic auth

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -7,13 +7,23 @@
 #include "include/router.h"
 #include "include/app.h"
 
+/* WARNING: Must be constant-time. Do NOT replace with strcmp() or any early-exit comparison. */
+static bool secureEquals(const char *a, const char *b) {
+    size_t lenA = strlen(a);
+    size_t lenB = strlen(b);
+    unsigned char result = (lenA != lenB);
+    for (size_t i = 0; i < lenA; i++) {
+        result |= (unsigned char)(a[i] ^ b[i % lenB]);
+    }
+    return result == 0;
+}
+
 BasicAuthenticator initBasicAuth() {
     BasicAuthenticator auth = {
         .credentials = malloc(sizeof(char *)),
         .credentialsCount = 0,
         .credentialsCapacity = 1
     };
-
     return auth;
 }
 
@@ -21,15 +31,14 @@ void addBasicCredentials(BasicAuthenticator *auth, char *username, char *passwor
     int credLen = strlen(username) + strlen(password) + 2;
     char *credentials = malloc(credLen);
     snprintf(credentials, credLen, "%s:%s", username, password);
-    
     char *encoded = base64Encode(credentials);
     free(credentials);
-    
     if (auth->credentialsCount >= auth->credentialsCapacity) {
         auth->credentialsCapacity *= 2;
-        auth->credentials = realloc(auth->credentials, sizeof(char *) * auth->credentialsCapacity);
+        char **tmp = realloc(auth->credentials, sizeof(char *) * auth->credentialsCapacity);
+        if (!tmp) return;
+        auth->credentials = tmp;
     }
-
     auth->credentials[auth->credentialsCount++] = strdup(encoded);
     free(encoded);
 }
@@ -42,13 +51,10 @@ HttpResponse basicAuth(RequestContext ctx, MiddlewareHandler *n) {
             break;
         }
     }
-
     if (!authHeader || strncmp(authHeader, "Basic ", 6) != 0) {
         return unauthorized("Unauthorized");
     }
-
     char *encodedCredentials = authHeader + 6;
-
     if (checkBasicCredentials(&ctx.app->auth, encodedCredentials)) {
         return next(ctx, n);
     } else {
@@ -58,11 +64,10 @@ HttpResponse basicAuth(RequestContext ctx, MiddlewareHandler *n) {
 
 bool checkBasicCredentials(BasicAuthenticator *auth, char *base64) {
     for (int i = 0; i < auth->credentialsCount; i++) {
-        if (strcmp(auth->credentials[i], base64) == 0) {
+        if (secureEquals(auth->credentials[i], base64)) {
             return true;
         }
     }
-
     return false;
 }
 
@@ -70,10 +75,8 @@ void freeBasicAuth(BasicAuthenticator auth) {
     if (!auth.credentials) {
         return;
     }
-
     for (int i = 0; i < auth.credentialsCount; i++) {
         free(auth.credentials[i]);
     }
-
     free(auth.credentials);
 }

--- a/test/auth_test.c
+++ b/test/auth_test.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../src/include/lavandula_test.h"
+#include "../src/include/auth.h"
+#include "../src/include/base64.h"
+
+void test_basic_auth_credentials() {
+    BasicAuthenticator auth = initBasicAuth();
+    addBasicCredentials(&auth, "admin", "secret123");
+    addBasicCredentials(&auth, "user", "pass");
+
+    char *authStr1 = base64Encode("admin:secret123");
+    char *authStr2 = base64Encode("user:pass");
+    char *authStr3 = base64Encode("admin:wrong");
+    char *authStr4 = base64Encode("nonexistent:user");
+
+    expect(checkBasicCredentials(&auth, authStr1), toBe(1));
+    expect(checkBasicCredentials(&auth, authStr2), toBe(1));
+    expect(checkBasicCredentials(&auth, authStr3), toBe(0));
+    expect(checkBasicCredentials(&auth, authStr4), toBe(0));
+
+    free(authStr1); free(authStr2); free(authStr3); free(authStr4);
+    freeBasicAuth(auth);
+}
+
+void test_basic_auth_empty_credentials() {
+    BasicAuthenticator auth = initBasicAuth();
+    char *authStr = base64Encode("admin:secret");
+    expect(checkBasicCredentials(&auth, authStr), toBe(0));
+    free(authStr);
+    freeBasicAuth(auth);
+}
+
+void run_auth_tests() {
+    runTest(test_basic_auth_credentials);
+    runTest(test_basic_auth_empty_credentials);
+}

--- a/test/tests.c
+++ b/test/tests.c
@@ -6,6 +6,7 @@ void run_lexer_tests();
 void run_parser_tests();
 void run_http_tests();
 void run_utils_tests();
+void run_auth_tests();
 
 int main() {
     printf("=== Lavandula Test Suite ===\n\n");
@@ -25,6 +26,9 @@ int main() {
     printf("\n");
     
     run_utils_tests();
+    printf("\n");
+    
+    run_auth_tests();
     printf("\n");
     
     printf("=== Final Test Results ===\n");


### PR DESCRIPTION
## Summary

This PR fixes a timing side-channel vulnerability in the basic authentication module.

## The Problem

In `src/auth.c`, `checkBasicCredentials()` used `strcmp()` to compare base64-encoded credentials:

```c
if (strcmp(auth->credentials[i], base64) == 0) {
```

`strcmp()` exits early on the first mismatched byte, creating a timing side-channel that could theoretically leak credential information one byte at a time.

## The Fix

Replaced `strcmp()` with `secureEquals()`, a constant-time comparison that always iterates all bytes using XOR and OR without data-dependent branching.

Also fixed a `realloc()` null-return handling bug and added tests.

## Changes

- `src/auth.c`: Added `secureEquals()` with safety comment, replaced `strcmp()`, fixed `realloc()` NULL check
- `test/auth_test.c`: New test file with credential validation tests
- `test/tests.c`: Added `run_auth_tests()` to test suite

Reported by a contributor who identified the timing oracle at line 61 of `src/auth.c`.