### PR TITLE
fix: replace strcmp() with constant-time comparison in BasicAuth to prevent timing oracle

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -6,6 +6,7 @@
 #include "include/base64.h"
 #include "include/router.h"
 #include "include/app.h"
+#include "include/utils.h"
 
 BasicAuthenticator initBasicAuth() {
     BasicAuthenticator auth = {
@@ -57,13 +58,13 @@ HttpResponse basicAuth(RequestContext ctx, MiddlewareHandler *n) {
 }
 
 bool checkBasicCredentials(BasicAuthenticator *auth, char *base64) {
+    bool found = false;
     for (int i = 0; i < auth->credentialsCount; i++) {
-        if (strcmp(auth->credentials[i], base64) == 0) {
-            return true;
+        if (constantTimeEquals(auth->credentials[i], base64)) {
+            found = true;
         }
     }
-
-    return false;
+    return found;
 }
 
 void freeBasicAuth(BasicAuthenticator auth) {

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -1,6 +1,9 @@
 #ifndef utils_h
 #define utils_h
 
+#include <stdbool.h>
+
 char *readFile(const char *filename);
+bool constantTimeEquals(const char *a, const char *b);
 
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -27,3 +27,15 @@ char *readFile(const char *path) {
 
     return buff;
 }
+
+bool constantTimeEquals(const char *a, const char *b) {
+    if (a == NULL || b == NULL) return false;
+    size_t lenA = strlen(a);
+    size_t lenB = strlen(b);
+    if (lenA != lenB) return false;
+    volatile unsigned char result = 0;
+    for (size_t i = 0; i < lenA; i++) {
+        result |= (unsigned char)(a[i] ^ b[i]);
+    }
+    return result == 0;
+}

--- a/test/auth_test.c
+++ b/test/auth_test.c
@@ -1,0 +1,115 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "../src/include/lavandula_test.h"
+#include "../src/include/utils.h"
+#include "../src/include/auth.h"
+
+void test_constant_time_equals_equal_strings() {
+    expect(constantTimeEquals("abc", "abc"), toBe(true));
+}
+
+void test_constant_time_equals_different_strings() {
+    expect(constantTimeEquals("abc", "xyz"), toBe(false));
+}
+
+void test_constant_time_equals_different_lengths() {
+    expect(constantTimeEquals("abc", "abcd"), toBe(false));
+}
+
+void test_constant_time_equals_empty_strings() {
+    expect(constantTimeEquals("", ""), toBe(true));
+}
+
+void test_constant_time_equals_null_a() {
+    expect(constantTimeEquals(NULL, "abc"), toBe(false));
+}
+
+void test_constant_time_equals_null_b() {
+    expect(constantTimeEquals("abc", NULL), toBe(false));
+}
+
+void test_constant_time_equals_both_null() {
+    expect(constantTimeEquals(NULL, NULL), toBe(false));
+}
+
+
+void test_check_basic_credentials_valid() {
+    BasicAuthenticator auth = initBasicAuth();
+    addBasicCredentials(&auth, (char*)"user", (char*)"pass");
+    /* The stored credential is base64 of "user:pass" = "dXNlcjpwYXNz" */
+    expect(checkBasicCredentials(&auth, "dXNlcjpwYXNz"), toBe(true));
+    freeBasicAuth(auth);
+}
+
+void test_check_basic_credentials_invalid() {
+    BasicAuthenticator auth = initBasicAuth();
+    addBasicCredentials(&auth, (char*)"user", (char*)"pass");
+    expect(checkBasicCredentials(&auth, "aW52YWxpZDpjcmlkcw=="), toBe(false));
+    freeBasicAuth(auth);
+}
+
+void test_check_basic_credentials_multiple_match_first() {
+    BasicAuthenticator auth = initBasicAuth();
+    addBasicCredentials(&auth, (char*)"user1", (char*)"pass1");
+    addBasicCredentials(&auth, (char*)"user2", (char*)"pass2");
+    /* base64 of "user1:pass1" = "dXNlcjE6cGFzczE=" */
+    expect(checkBasicCredentials(&auth, "dXNlcjE6cGFzczE="), toBe(true));
+    freeBasicAuth(auth);
+}
+
+void test_check_basic_credentials_multiple_match_last() {
+    BasicAuthenticator auth = initBasicAuth();
+    addBasicCredentials(&auth, (char*)"user1", (char*)"pass1");
+    addBasicCredentials(&auth, (char*)"user2", (char*)"pass2");
+    /* base64 of "user2:pass2" = "dXNlcjI6cGFzczI=" */
+    expect(checkBasicCredentials(&auth, "dXNlcjI6cGFzczI="), toBe(true));
+    freeBasicAuth(auth);
+}
+
+void test_check_basic_credentials_no_match() {
+    BasicAuthenticator auth = initBasicAuth();
+    addBasicCredentials(&auth, (char*)"user1", (char*)"pass1");
+    addBasicCredentials(&auth, (char*)"user2", (char*)"pass2");
+    expect(checkBasicCredentials(&auth, "bm9uZTptYXRjaA=="), toBe(false));
+    freeBasicAuth(auth);
+}
+
+void test_check_basic_credentials_empty_db() {
+    BasicAuthenticator auth = initBasicAuth();
+    expect(checkBasicCredentials(&auth, "dXNlcjpwYXNz"), toBe(false));
+    freeBasicAuth(auth);
+}
+
+
+void test_constant_time_equals_no_early_exit() {
+    /* Verify function doesn't early-exit by testing all positions */
+    expect(constantTimeEquals("aaaaaaaa", "baaaaaaa"), toBe(false));
+    expect(constantTimeEquals("aaaaaaaa", "abaaaaaa"), toBe(false));
+    expect(constantTimeEquals("aaaaaaaa", "aabaaaaa"), toBe(false));
+    expect(constantTimeEquals("aaaaaaaa", "aaabaaaa"), toBe(false));
+    expect(constantTimeEquals("aaaaaaaa", "aaaabaaa"), toBe(false));
+    expect(constantTimeEquals("aaaaaaaa", "aaaaabaa"), toBe(false));
+    expect(constantTimeEquals("aaaaaaaa", "aaaaaaba"), toBe(false));
+    expect(constantTimeEquals("aaaaaaaa", "aaaaaaab"), toBe(false));
+    /* All should return false - if function early-exited, any could fail */
+}
+
+void run_auth_tests() {
+    runTest(test_constant_time_equals_equal_strings);
+    runTest(test_constant_time_equals_different_strings);
+    runTest(test_constant_time_equals_different_lengths);
+    runTest(test_constant_time_equals_empty_strings);
+    runTest(test_constant_time_equals_null_a);
+    runTest(test_constant_time_equals_null_b);
+    runTest(test_constant_time_equals_both_null);
+    runTest(test_constant_time_equals_no_early_exit);
+    runTest(test_check_basic_credentials_valid);
+    runTest(test_check_basic_credentials_invalid);
+    runTest(test_check_basic_credentials_multiple_match_first);
+    runTest(test_check_basic_credentials_multiple_match_last);
+    runTest(test_check_basic_credentials_no_match);
+    runTest(test_check_basic_credentials_empty_db);
+}

--- a/test/tests.c
+++ b/test/tests.c
@@ -6,35 +6,31 @@ void run_lexer_tests();
 void run_parser_tests();
 void run_http_tests();
 void run_utils_tests();
+void run_auth_tests();
 
 int main() {
     printf("=== Lavandula Test Suite ===\n\n");
-    
     testsRan = 0;
     testsFailed = 0;
     assertions = 0;
     assertionsFailed = 0;
-    
     run_lexer_tests();
     printf("\n");
-    
     run_parser_tests();
     printf("\n");
-    
     run_http_tests();
     printf("\n");
-    
     run_utils_tests();
     printf("\n");
-    
+    run_auth_tests();
+    printf("\n");
     printf("=== Final Test Results ===\n");
     testResults();
-    
     if (testsFailed > 0 || assertionsFailed > 0) {
-        printf("❌ Some tests failed!\n");
+        printf("\u274c Some tests failed!\n");
         return 1;
     } else {
-        printf("✅ All tests passed!\n");
+        printf("\u2705 All tests passed!\n");
         return 0;
     }
 }


### PR DESCRIPTION
## Summary

Replaces  with a constant-time comparison function in  to prevent timing oracle attacks. Also removes the early-exit loop that could leak which credential index matched.

## Changes

- **src/include/utils.h**: Added  declaration
- **src/utils.c**: Added XOR-based constant-time string comparison
- **src/auth.c**: Updated  to use  and iterate all credentials without early return
- **test/auth_test.c**: 14 test cases covering the comparison function and authentication flow
- **test/tests.c**: Registered the new auth test suite

## Vulnerability

The original code used `strcmp()` which returns early at the first differing byte, and the loop returned early on the first matching credential. Both leaks allow timing-based information extraction.

Fixes the timing oracle vulnerability reported against commit 3333c76.